### PR TITLE
[Update] 時間制限UIの強化対応

### DIFF
--- a/Assets/Prefabs/InGame/UI/Component/GravityLimitUICanvas.prefab
+++ b/Assets/Prefabs/InGame/UI/Component/GravityLimitUICanvas.prefab
@@ -85,7 +85,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!114 &7429539130802700787
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -207,6 +207,81 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   targetCamera: {fileID: 0}
   objectToRotate: {fileID: 7098878325863139135}
+--- !u!1 &2836084323885146927
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6844034295553497839}
+  - component: {fileID: 4679522585272590549}
+  - component: {fileID: 883683120607875992}
+  m_Layer: 5
+  m_Name: TimerGaugeSecond
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6844034295553497839
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2836084323885146927}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.9, y: 1.9, z: 1.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3780695065845485039}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 70, y: 70}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4679522585272590549
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2836084323885146927}
+  m_CullTransparentMesh: 1
+--- !u!114 &883683120607875992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2836084323885146927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 6ba1fbb1a8c2c5947ad3db8564cb752b, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 0.76
+  m_FillClockwise: 0
+  m_FillOrigin: 2
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1001 &559629955975552404
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -307,13 +382,20 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4937643805308274178, guid: 34c3b845171c5294681a16fe7620ad02, type: 3}
+      propertyPath: secondLoopGauge
+      value: 
+      objectReference: {fileID: 883683120607875992}
     - target: {fileID: 6949308023190928949, guid: 34c3b845171c5294681a16fe7620ad02, type: 3}
       propertyPath: m_Name
       value: GravityTimeLimit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 3725477840278114427, guid: 34c3b845171c5294681a16fe7620ad02, type: 3}
+      insertIndex: 0
+      addedObject: {fileID: 6844034295553497839}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 34c3b845171c5294681a16fe7620ad02, type: 3}
 --- !u!224 &3780695065845485039 stripped

--- a/Assets/Prefabs/InGame/UI/Component/GravityLimitUICanvas.prefab
+++ b/Assets/Prefabs/InGame/UI/Component/GravityLimitUICanvas.prefab
@@ -85,7 +85,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 1
+  m_PresetInfoIsWorld: 0
 --- !u!114 &7429539130802700787
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -207,81 +207,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   targetCamera: {fileID: 0}
   objectToRotate: {fileID: 7098878325863139135}
---- !u!1 &2836084323885146927
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6844034295553497839}
-  - component: {fileID: 4679522585272590549}
-  - component: {fileID: 883683120607875992}
-  m_Layer: 5
-  m_Name: TimerGaugeSecond
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &6844034295553497839
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2836084323885146927}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.9, y: 1.9, z: 1.9}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3780695065845485039}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 70, y: 70}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &4679522585272590549
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2836084323885146927}
-  m_CullTransparentMesh: 1
---- !u!114 &883683120607875992
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2836084323885146927}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 6ba1fbb1a8c2c5947ad3db8564cb752b, type: 3}
-  m_Type: 3
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 0.76
-  m_FillClockwise: 0
-  m_FillOrigin: 2
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1001 &559629955975552404
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -385,19 +310,27 @@ PrefabInstance:
     - target: {fileID: 4937643805308274178, guid: 34c3b845171c5294681a16fe7620ad02, type: 3}
       propertyPath: secondLoopGauge
       value: 
-      objectReference: {fileID: 883683120607875992}
+      objectReference: {fileID: 3435776538504184493}
     - target: {fileID: 6949308023190928949, guid: 34c3b845171c5294681a16fe7620ad02, type: 3}
       propertyPath: m_Name
       value: GravityTimeLimit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 3725477840278114427, guid: 34c3b845171c5294681a16fe7620ad02, type: 3}
-      insertIndex: 0
-      addedObject: {fileID: 6844034295553497839}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 34c3b845171c5294681a16fe7620ad02, type: 3}
+--- !u!114 &3435776538504184493 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2912246710988103481, guid: 34c3b845171c5294681a16fe7620ad02, type: 3}
+  m_PrefabInstance: {fileID: 559629955975552404}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &3780695065845485039 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3725477840278114427, guid: 34c3b845171c5294681a16fe7620ad02, type: 3}

--- a/Assets/Prefabs/InGame/UI/Component/GravityTimeLimit.prefab
+++ b/Assets/Prefabs/InGame/UI/Component/GravityTimeLimit.prefab
@@ -1,5 +1,80 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &749200534335340545
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2994704521385202868}
+  - component: {fileID: 7180663267703456783}
+  - component: {fileID: 2912246710988103481}
+  m_Layer: 5
+  m_Name: TimerGaugeSecond
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2994704521385202868
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 749200534335340545}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.9, y: 1.9, z: 1.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3725477840278114427}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 70, y: 70}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7180663267703456783
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 749200534335340545}
+  m_CullTransparentMesh: 1
+--- !u!114 &2912246710988103481
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 749200534335340545}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 6ba1fbb1a8c2c5947ad3db8564cb752b, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 0.76
+  m_FillClockwise: 0
+  m_FillOrigin: 2
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &2192610764009823955
 GameObject:
   m_ObjectHideFlags: 0
@@ -391,6 +466,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 2994704521385202868}
   - {fileID: 8183642614353364351}
   - {fileID: 999310933411369079}
   - {fileID: 5795598177317594664}
@@ -423,3 +499,4 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   fillGauge: {fileID: 3116441267848661610}
+  secondLoopGauge: {fileID: 2912246710988103481}

--- a/Assets/Scenes/Hank/UpdateLimitUI.unity
+++ b/Assets/Scenes/Hank/UpdateLimitUI.unity
@@ -6276,6 +6276,11 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!224 &798961743 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3780695065845485039, guid: c759c3b6bd0871e4888d2104b886ef67, type: 3}
+  m_PrefabInstance: {fileID: 2508698047475743361}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &799026255 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -4636156045375749406, guid: d6e09f6f01fc4904dab1fafe79abf198, type: 3}
@@ -7984,6 +7989,81 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: -584911435688131278, guid: d6e09f6f01fc4904dab1fafe79abf198, type: 3}
+--- !u!1 &862598232
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 862598233}
+  - component: {fileID: 862598235}
+  - component: {fileID: 862598234}
+  m_Layer: 5
+  m_Name: TimerGaugeSecond
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &862598233
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 862598232}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.9, y: 1.9, z: 1.9}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 798961743}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 70, y: 70}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &862598234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 862598232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 6ba1fbb1a8c2c5947ad3db8564cb752b, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 0.76
+  m_FillClockwise: 0
+  m_FillOrigin: 2
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &862598235
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 862598232}
+  m_CullTransparentMesh: 1
 --- !u!1 &864828482 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -4579017534769393355, guid: d6e09f6f01fc4904dab1fafe79abf198, type: 3}
@@ -13523,6 +13603,22 @@ PrefabInstance:
       propertyPath: sceneStateController
       value: 
       objectReference: {fileID: 1854431660}
+    - target: {fileID: 6766105230908824644, guid: 78427516f57ec4d4aa8a19959b7e096b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6766105230908824644, guid: 78427516f57ec4d4aa8a19959b7e096b, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6766105230908824644, guid: 78427516f57ec4d4aa8a19959b7e096b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6766105230908824644, guid: 78427516f57ec4d4aa8a19959b7e096b, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8076797359267270946, guid: 78427516f57ec4d4aa8a19959b7e096b, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -17250,6 +17346,22 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 446015120}
     m_Modifications:
+    - target: {fileID: 132647317431774023, guid: 7b7bffc3bd9186a4fb4d379c3588e45a, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1686583466}
+    - target: {fileID: 4721723034972518916, guid: 7b7bffc3bd9186a4fb4d379c3588e45a, type: 3}
+      propertyPath: oldScale.x
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4721723034972518916, guid: 7b7bffc3bd9186a4fb4d379c3588e45a, type: 3}
+      propertyPath: oldScale.z
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5264362781780093252, guid: 7b7bffc3bd9186a4fb4d379c3588e45a, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f50c407272a31384e9c3ed3475be3fdd, type: 2}
     - target: {fileID: 3184935648405498308, guid: 15ae69178a2aef1478e8e376e3d6dad1, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
@@ -17314,22 +17426,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 132647317431774023, guid: 7b7bffc3bd9186a4fb4d379c3588e45a, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1686583466}
-    - target: {fileID: 4721723034972518916, guid: 7b7bffc3bd9186a4fb4d379c3588e45a, type: 3}
-      propertyPath: oldScale.x
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 4721723034972518916, guid: 7b7bffc3bd9186a4fb4d379c3588e45a, type: 3}
-      propertyPath: oldScale.z
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 5264362781780093252, guid: 7b7bffc3bd9186a4fb4d379c3588e45a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f50c407272a31384e9c3ed3475be3fdd, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -19995,6 +20091,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 456644613}
     m_Modifications:
+    - target: {fileID: 1383992431240490696, guid: c759c3b6bd0871e4888d2104b886ef67, type: 3}
+      propertyPath: m_PresetInfoIsWorld
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1716857685243942504, guid: c759c3b6bd0871e4888d2104b886ef67, type: 3}
       propertyPath: m_Name
       value: GravityLimitUI
@@ -20007,6 +20107,10 @@ PrefabInstance:
       propertyPath: targetCamera
       value: 
       objectReference: {fileID: 1640154085}
+    - target: {fileID: 4846502787726039958, guid: c759c3b6bd0871e4888d2104b886ef67, type: 3}
+      propertyPath: secondLoopGauge
+      value: 
+      objectReference: {fileID: 862598234}
     - target: {fileID: 5608917369686347368, guid: c759c3b6bd0871e4888d2104b886ef67, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -20093,7 +20197,10 @@ PrefabInstance:
       objectReference: {fileID: 1640154085}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 3780695065845485039, guid: c759c3b6bd0871e4888d2104b886ef67, type: 3}
+      insertIndex: 0
+      addedObject: {fileID: 862598233}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c759c3b6bd0871e4888d2104b886ef67, type: 3}
 --- !u!1001 &2670281799265963325

--- a/Assets/Scripts/Behaviour/UI/InGame/GravityLimit/GravityTimerUI.cs
+++ b/Assets/Scripts/Behaviour/UI/InGame/GravityLimit/GravityTimerUI.cs
@@ -85,7 +85,7 @@ namespace Behaviour.UI
                 return;
 
             var currentLevel = playerDataController.PlayerData.GetLevel(UpgradeType.OperationDuration);
-            var maxLevel = upgradeData.UpgradedParams.Length - 1;
+            var maxLevel = upgradeData.UpgradedParams.Length;
             if (maxLevel <= 0)
                 return;
 

--- a/Assets/Scripts/Behaviour/UI/InGame/GravityLimit/GravityTimerUI.cs
+++ b/Assets/Scripts/Behaviour/UI/InGame/GravityLimit/GravityTimerUI.cs
@@ -1,6 +1,8 @@
 using UnityEngine;
 using UnityEngine.UI;
 using Behaviour.Gravity;
+using Behaviour.Controller.General.DontDestoroy;
+using ScriptableObj.Upgrade;
 
 namespace Behaviour.UI
 {
@@ -12,18 +14,41 @@ namespace Behaviour.UI
         [SerializeField]
         private Image fillGauge; // Fill Amountで制御するゲージ
 
+        [SerializeField]
+        private Image secondLoopGauge; // 二周目用ゲージ
+
         private GravityOperationManager _manager;
+
+        private float _secondLoopMaxFill;
+
+        private float _totalGaugeCapacity = 1f;
 
         private void Start()
         {
             _manager = GravityOperationManager.Instance;
+            if (_manager == null)
+            {
+                Debug.LogError("GravityOperationManager が取得できません。");
+                return;
+            }
+
+            InitializeSecondLoopCapacity();
             
             // 残り時間割合の変更イベントを購読
             _manager.OnOperationRemainingRatioChanged += OnTimerChanged;
             _manager.OnOperationCountChanged += OnOperationCountChanged;
             
             // 初期状態ではゲージをマックスにする
-            fillGauge.fillAmount = 1f;
+            ApplyGaugeByRatio(1f);
+        }
+
+        private void OnDestroy()
+        {
+            if (_manager == null)
+                return;
+
+            _manager.OnOperationRemainingRatioChanged -= OnTimerChanged;
+            _manager.OnOperationCountChanged -= OnOperationCountChanged;
         }
 
         /// <summary>
@@ -31,8 +56,7 @@ namespace Behaviour.UI
         /// </summary>
         private void OnTimerChanged(VGravBehaviour target, float ratio)
         {
-            // Fill Amount を更新
-            fillGauge.fillAmount = ratio;
+            ApplyGaugeByRatio(ratio);
         }
 
         /// <summary>
@@ -43,8 +67,54 @@ namespace Behaviour.UI
             // 操作中でなければゲージをマックスにする
             if (activeCount == 0)
             {
-                fillGauge.fillAmount = 1f;
+                ApplyGaugeByRatio(1f);
             }
+        }
+
+        private void InitializeSecondLoopCapacity()
+        {
+            _secondLoopMaxFill = 0f;
+            _totalGaugeCapacity = 1f;
+
+            var playerDataController = PlayerDataController.Instance;
+            if (playerDataController == null)
+                return;
+
+            var upgradeData = playerDataController.GetUpgradeData(UpgradeType.OperationDuration) as ParamUpgrade;
+            if (upgradeData == null)
+                return;
+
+            var currentLevel = playerDataController.PlayerData.GetLevel(UpgradeType.OperationDuration);
+            var maxLevel = upgradeData.UpgradedParams.Length - 1;
+            if (maxLevel <= 0)
+                return;
+
+            _secondLoopMaxFill = Mathf.Clamp01((float)currentLevel / maxLevel);
+            _totalGaugeCapacity = 1f + _secondLoopMaxFill;
+        }
+
+        private void ApplyGaugeByRatio(float ratio)
+        {
+            var clampedRatio = Mathf.Clamp01(ratio);
+
+            if (fillGauge == null)
+                return;
+
+            if (secondLoopGauge == null)
+            {
+                fillGauge.fillAmount = clampedRatio;
+                return;
+            }
+
+            var totalRemaining = clampedRatio * _totalGaugeCapacity;
+
+            // 二周目が先に減り、二周目が尽きたら一周目を減らす
+            var secondLoopFill = Mathf.Clamp(totalRemaining - 1f, 0f, _secondLoopMaxFill);
+            var firstLoopFill = Mathf.Clamp01(Mathf.Min(totalRemaining, 1f));
+
+            secondLoopGauge.fillAmount = secondLoopFill;
+            secondLoopGauge.gameObject.SetActive(_secondLoopMaxFill > 0f);
+            fillGauge.fillAmount = firstLoopFill;
         }
     }
 }

--- a/Assets/Scripts/Behaviour/UI/InGame/GravityLimit/GravityTimerUI.cs
+++ b/Assets/Scripts/Behaviour/UI/InGame/GravityLimit/GravityTimerUI.cs
@@ -25,10 +25,18 @@ namespace Behaviour.UI
 
         private void Start()
         {
+            if (fillGauge == null)
+            {
+                Debug.LogError("fillGauge が未設定です。", this);
+                enabled = false;
+                return;
+            }
+
             _manager = GravityOperationManager.Instance;
             if (_manager == null)
             {
                 Debug.LogError("GravityOperationManager が取得できません。");
+                enabled = false;
                 return;
             }
 
@@ -96,9 +104,6 @@ namespace Behaviour.UI
         private void ApplyGaugeByRatio(float ratio)
         {
             var clampedRatio = Mathf.Clamp01(ratio);
-
-            if (fillGauge == null)
-                return;
 
             if (secondLoopGauge == null)
             {

--- a/Assets/Scripts/Behaviour/UI/Upgrade/UpgradeUIController.cs
+++ b/Assets/Scripts/Behaviour/UI/Upgrade/UpgradeUIController.cs
@@ -157,8 +157,13 @@ namespace Behaviour.UI.Upgrade
                     var unit = paramUpgrade.Unit;
                     var param = paramUpgrade.UpgradedParams;
 
-                    var cur = param[curLevel];
-                    var next = param[curLevel + 1];
+                    var cur = type switch
+                    {
+                        UpgradeType.OperationDuration => playerData.OperationDuration,
+                        UpgradeType.MaxOperationCount => playerData.MaxCurrentOperations,
+                        _ => throw new NotImplementedException()
+                    };
+                    var next = param[curLevel];
                     var diff = next -cur;
 
                     content = $"{cur}{unit} →　{next}{unit}(↑{diff})";

--- a/Assets/Scripts/ScriptableObj/Upgrade/ParamUpgrade.cs
+++ b/Assets/Scripts/ScriptableObj/Upgrade/ParamUpgrade.cs
@@ -31,7 +31,7 @@ namespace ScriptableObj.Upgrade
         {
             var nextLevel = playerData.GetLevel(UpgradeType) + 1;
 
-            return nextLevel < upgradedParams.Length;
+            return nextLevel <= upgradedParams.Length;
         }
     }
 }


### PR DESCRIPTION
## 概要
- 重力操作時間のUIを強化レベルに連動させ、二周目ゲージ表示に対応しました。
- 強化データの上限判定とUI表示ロジックの整合を取り、操作時間が最終値まで到達できるように修正しました。

## 実装内容
- 操作時間UIを2リング表示に対応
- 1周目ゲージ + 2周目ゲージを扱うように変更
- 2周目表示率は OperationDuration の強化レベル進行率で算出

## 強化上限の到達不整合を修正
- アップグレード上限判定を修正

  - 上限判定は ParamUpgrade.cs で nextLevel < upgradedParams.Length になっており、長さ3だと実行可能なのは実質2回だった

- 最終段階付近で発生する配列参照不整合を回避し、現在値→次値表示を実データ基準に調整

### 主な変更ファイル
- GravityTimerUI.cs
- ParamUpgrade.cs
- UpgradeUIController.cs

## 操作時間UI強化のテスト方法
### テスト場所
Gravity UIプレハブ: GravityTimeLimit.prefab

### 手順
強化なしでプレイし、2周目ゲージが表示されない（または0%）ことを確認
OperationDuration を中間レベルまで強化し、2周目が部分表示されることを確認
最大レベルまで強化し、2周目が100%表示されることを確認
重力操作中にゲージが「2周目→1周目」の順で減少することを確認
操作終了時に1周目が満タン、2周目がレベル進行率分に復帰することを確認

## アップグレード上限修正について
- 上限判定条件と強化値配列の参照インデックスが1段ずれており、最終値が適用されない状態だった
対応
- 上限判定を到達可能な条件に修正
- 併せて強化UIの次値表示ロジックを調整して、最終段階でも破綻しないように修正
**何か意図があって上限判定をずらしていたなら戻してください**